### PR TITLE
ci: cap apt-get update at 5 minutes

### DIFF
--- a/.github/workflows/run-tests-and-publish-report.yml
+++ b/.github/workflows/run-tests-and-publish-report.yml
@@ -28,6 +28,7 @@ jobs:
           cache-dependency-glob: "**/uv.lock"
 
       - name: Install system dependencies (Graphviz)
+        timeout-minutes: 5
         run: |
           sudo apt-get update
           sudo apt-get install -y graphviz


### PR DESCRIPTION
## Summary
- The last \`run-tests-and-publish-report\` workflow ran for 6h 5m before being cancelled at the default job timeout. Logs show \`apt-get update\` repeatedly retrying against an unreachable \`azure.archive.ubuntu.com\` mirror.
- This caps the Graphviz install step at 5 minutes so transient Azure-mirror outages produce a fast, retriable failure instead of consuming the full 6-hour ceiling.

## Test plan
- [ ] Trigger \`run-tests-and-publish-report\` against this branch via \`workflow_dispatch\` and confirm the install step either succeeds (mirror healthy) or fails within 5 minutes (mirror still flaky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)