### PR TITLE
fix(tests): plot_community_dfba ignores non-process state entries

### DIFF
--- a/spatio_flux/experiments/test_suite.py
+++ b/spatio_flux/experiments/test_suite.py
@@ -119,7 +119,13 @@ def plot_dfba_single(results, state, config=None, filename='dfba_single_timeseri
 def plot_community_dfba(results, state, config=None):
     config = config or {}
     filename = config.get('filename', 'dfba_multi_timeseries.png')
-    species_ids = [state[s]['inputs']['biomass'][-1] for s in state.keys() if s not in ['fields', 'emitter', 'global_time']]
+    species_ids = [
+        entry['inputs']['biomass'][-1]
+        for entry in state.values()
+        if isinstance(entry, dict)
+        and isinstance(entry.get('inputs'), dict)
+        and 'biomass' in entry['inputs']
+    ]
     plot_time_series(results, field_names=species_ids, log_scale=True, normalize=True, out_dir='out', filename=filename,
                      title='hybrid community',
                      figsize=(4.5, 3.5),


### PR DESCRIPTION
## Summary
- \`plot_community_dfba\` iterated \`state.keys()\` with a small exclusion list (\`fields\`, \`emitter\`, \`global_time\`) and assumed every remaining entry was a process with \`inputs.biomass\`.
- Commit 2daff23 added \`viz_timeseries\` (a Step with \`inputs\` but no \`biomass\` child) and \`viz_timeseries_html\` (a string) to several composites, so the assumption broke and the test suite raised \`KeyError: 'biomass'\` once \`community_dfba\` finished simulating.
- Replaces the name-based exclusion with a structural filter: keep only entries that are dicts whose \`inputs\` dict has a \`biomass\` key. Same intent, immune to future composite additions.

## Test plan
- [x] Reproduced \`KeyError: 'biomass'\` locally with \`uv run python spatio_flux/experiments/test_suite.py --tests community_dfba\`.
- [x] After fix, same command completes; \`out/community_dfba.png\` renders the expected 7 species lines (6 dFBA + 1 Monod biomass).
- [ ] Dispatched workflow run against this branch is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)