### PR TITLE
ci: add fast unit-tests workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,39 @@
+name: Unit tests
+
+on:
+  pull_request:
+    paths:
+      - 'spatio_flux/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/unit-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'spatio_flux/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/unit-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
+
+      - name: Install dependencies
+        run: uv sync --frozen --group dev
+
+      - name: Run pytest
+        run: uv run pytest tests/ -q


### PR DESCRIPTION
## Summary
- Adds \`.github/workflows/unit-tests.yml\` that runs \`pytest tests/\` (33 tests, ~3s locally) on every PR and on push-to-main.
- Same path filters as the slow report workflow plus \`tests/**\`. The existing simulation+report workflow is unchanged — it still runs on push-to-main and publishes the report.
- Motivation: report workflow is ~20–28 min; PR feedback was effectively absent. This gives sub-minute green/red on PRs.

## Test plan
- [ ] This PR's \`Unit tests\` check goes green in under ~2 min total wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)