### PR TITLE
ci: fan out test suite into a 19-job matrix

### DIFF
--- a/.github/workflows/run-tests-and-publish-report.yml
+++ b/.github/workflows/run-tests-and-publish-report.yml
@@ -12,11 +12,69 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-tests:
+  run-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - monod_kinetics
+          - ecoli_core_dfba
+          - ecoli_dfba
+          - yeast_dfba
+          - community_dfba
+          - dfba_kinetics_community
+          - spatial_many_dfba
+          - spatial_dfba_process
+          - diffusion_process
+          - brownian_particles
+          - br_particles_kinetics
+          - br_particles_dfba
+          - comets_diffusion
+          - comets_br_particles_kinetics
+          - comets_br_particles_dfba
+          - newtonian_particles
+          - comets_nt_particles_dfba
+          - spatioflux_reference_demo
+          - reference_demo_x2y2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+          enable-cache: true
+          cache-dependency-glob: "**/uv.lock"
+
+      - name: Install system dependencies (Graphviz)
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+
+      - name: Install Python dependencies with uv
+        run: uv sync --frozen
+
+      - name: Run test
+        run: |
+          mkdir -p out
+          uv run python spatio_flux/experiments/test_suite.py --tests ${{ matrix.test }} --output out
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: out-${{ matrix.test }}
+          path: out/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: run-test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Needed for gh-pages access
 
@@ -34,15 +92,18 @@ jobs:
           sudo apt-get install -y graphviz
 
       - name: Install Python dependencies with uv
-        run: |
-          # --frozen refuses to install if uv.lock doesn't match
-          # pyproject.toml, so silent dep drift becomes a loud failure.
-          uv sync --frozen
+        run: uv sync --frozen
 
-      - name: Run tests and generate report
+      - name: Download all test artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: out-*
+          merge-multiple: true
+          path: out
+
+      - name: Compile HTML report
         run: |
-          mkdir -p out
-          uv run python spatio_flux/experiments/test_suite.py --output out
+          uv run python spatio_flux/experiments/test_suite.py --skip-existing --output out
 
       - name: Commit and push report to gh-pages
         run: |
@@ -50,19 +111,15 @@ jobs:
           git config --local user.name "GitHub Action"
           git fetch origin
 
-          # Rename report.html to index.html for GitHub Pages compatibility
           mv out/report.html out/index.html
 
-          # Switch to gh-pages branch (create if needed)
           git checkout gh-pages || git checkout --orphan gh-pages
           git pull origin gh-pages || true
 
-          # Clear previous report, then copy updated content
           rm -rf report
           mkdir -p report
           cp -r out/* report/
 
-          # Commit and push only if there are changes
           git add report/
           git diff-index --quiet HEAD || git commit -m "Update simulation test report"
           git push origin gh-pages || true

--- a/spatio_flux/experiments/test_suite.py
+++ b/spatio_flux/experiments/test_suite.py
@@ -16,6 +16,7 @@ Usage:
 """
 import argparse
 import gc
+import json
 import os
 import time
 import matplotlib.pyplot as plt
@@ -566,6 +567,13 @@ def main():
 
         if args.skip_existing and _existing_outputs_for(name, output_dir):
             print(f"⏭️  Skipping '{name}' (cached outputs already exist)")
+            timing_path = os.path.join(output_dir, f"{name}_timing.json")
+            if os.path.exists(timing_path):
+                with open(timing_path) as f:
+                    t = json.load(f)
+                runtimes[name] = t["elapsed"]
+                timing_details[name] = (t["process_time"], t["framework_time"])
+                total_sim_time += t["elapsed"]
             continue
 
         sim_info = SIMULATIONS[name]
@@ -593,6 +601,12 @@ def main():
         runtimes[name] = sim_elapsed
         timing_details[name] = (proc_time, fw_time)
         total_sim_time += sim_elapsed
+        with open(os.path.join(output_dir, f"{name}_timing.json"), "w") as f:
+            json.dump({
+                "process_time": proc_time,
+                "framework_time": fw_time,
+                "elapsed": sim_elapsed,
+            }, f)
 
         print("Generating plots...")
         plot_config = sim_info.get('plot_config', {})


### PR DESCRIPTION
## Summary
- Replaces the single-job simulation+report workflow with a per-test matrix (\`run-test\`) plus a consolidation job (\`publish\`).
- Wall clock target: **~10-12 min** (heaviest single test), down from **~60 min** (sequential total) on the prior run.
- Same runner-minute budget; same gh-pages output; same failure semantics (\`publish\` only runs when every matrix job is green, per strict gating).

## How it works
1. **\`run-test\`** matrix-fans out the 19 tests with \`fail-fast: false\`. Each job runs \`test_suite.py --tests <name> --output out\` and uploads \`out/\` as artifact \`out-<name>\`.
2. **\`publish\`** (\`needs: run-test\`) downloads all artifacts \`merge-multiple\` into \`out/\`, runs \`test_suite.py --skip-existing\` (no resimulation — just HTML compile), then pushes the report to gh-pages.
3. \`test_suite.py\` now persists \`<test>_timing.json\` per run and reloads it on \`--skip-existing\`, so the consolidated report retains full per-test runtime data rather than blank \"Runtime:\" cells.

## Test plan
- [ ] Dispatched workflow run on this branch fans out 19 matrix jobs; all go green.
- [ ] \`publish\` job runs after, downloads artifacts, compiles HTML.
- [ ] Total wall clock under 15 min.
- [ ] gh-pages report on the branch shows runtime values per test (verified by skip-existing path persisting timing data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)