### PR TITLE
perf(viz): render-at-end by default (~6× CI speedup)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "imageio",
     "ipython",
     "matplotlib",
-    "pbg-superpowers>=0.4.16",
+    "pbg-superpowers>=0.9.0",
     "pymunk",
     "scipy",
 ]

--- a/spatio_flux/visualizations/field_animation_gif.py
+++ b/spatio_flux/visualizations/field_animation_gif.py
@@ -81,7 +81,7 @@ class FieldAnimationGif(Visualization):
         fields = (getattr(self, "config", None) or {}).get("field_names") or []
         return {name: {"_type": "array", "_data": "float"} for name in fields}
 
-    def update(self, state):
+    def accumulate(self, state):
         if not hasattr(self, "_history") or self._history is None:
             self._history = []
         fields = (getattr(self, "config", None) or {}).get("field_names") or []
@@ -92,9 +92,8 @@ class FieldAnimationGif(Visualization):
                 snap[name] = arr
         if snap:
             self._history.append(snap)
-        return {"html": self._render()}
 
-    def _render(self) -> str:
+    def render(self) -> str:
         cfg = getattr(self, "config", None) or {}
         fields = cfg.get("field_names") or []
         title = cfg.get("title", "field animation")

--- a/spatio_flux/visualizations/field_heatmap.py
+++ b/spatio_flux/visualizations/field_heatmap.py
@@ -5,9 +5,9 @@ store; the heatmap captures the latest grid state into HTML so the dashboard
 can preview the spatial pattern after a run.
 
 The viz accepts the field either as ``list[list[float]]`` or as a numpy
-ndarray (which it will convert). Streaming mode: each step replaces the
-rendered snapshot with the latest grid; ``render_results`` returns the most
-recent snapshot.
+ndarray (which it will convert). Default ``render_mode='end'``: accumulate
+the latest field each tick, render once via :func:`render_results`. Set
+``render_mode='stream'`` to render per-tick (legacy behaviour).
 """
 from __future__ import annotations
 import json
@@ -50,8 +50,13 @@ class FieldHeatmap(Visualization):
         # (spatial composites) or a list-of-lists; ``_to_2d_list`` normalises.
         return {'field': {'_type': 'array', '_data': 'float'}}
 
-    def update(self, state):
-        field = _to_2d_list(state.get('field'))
+    def accumulate(self, state):
+        # FieldHeatmap is a "latest snapshot" viz — no history, just the
+        # most recent grid.
+        self._last_field = _to_2d_list(state.get('field'))
+
+    def render(self):
+        field = getattr(self, '_last_field', None) or []
         title = (getattr(self, 'config', None) or {}).get('title', '')
         colorscale = (getattr(self, 'config', None) or {}).get(
             'colorscale', 'Viridis')
@@ -67,15 +72,13 @@ class FieldHeatmap(Visualization):
             'yaxis': {'title': {'text': 'y'}, 'scaleanchor': 'x'},
             'height': 360,
         }
-        return {
-            'html': (
-                '<div id="viz" style="height:360px"></div>'
-                '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
-                '<script>Plotly.newPlot("viz", ' + json.dumps(traces) + ', '
-                + json.dumps(layout)
-                + ', {responsive:true, displayModeBar:false});</script>'
-            )
-        }
+        return (
+            '<div id="viz" style="height:360px"></div>'
+            '<script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>'
+            '<script>Plotly.newPlot("viz", ' + json.dumps(traces) + ', '
+            + json.dumps(layout)
+            + ', {responsive:true, displayModeBar:false});</script>'
+        )
 
     @classmethod
     def demo(cls):

--- a/spatio_flux/visualizations/field_snapshots.py
+++ b/spatio_flux/visualizations/field_snapshots.py
@@ -76,7 +76,7 @@ class FieldSnapshotsGrid(Visualization):
         # Generic array type — store may be ndarray or list-of-lists.
         return {name: {"_type": "array", "_data": "float"} for name in fields}
 
-    def update(self, state):
+    def accumulate(self, state):
         if not hasattr(self, "_history") or self._history is None:
             self._history = []
         fields = (getattr(self, "config", None) or {}).get("field_names") or []
@@ -87,9 +87,8 @@ class FieldSnapshotsGrid(Visualization):
                 snap[name] = arr
         if snap:
             self._history.append(snap)
-        return {"html": self._render()}
 
-    def _render(self) -> str:
+    def render(self) -> str:
         cfg = getattr(self, "config", None) or {}
         fields = cfg.get("field_names") or []
         n_snap = max(1, int(cfg.get("n_snapshots", 4)))

--- a/spatio_flux/visualizations/particle_traces.py
+++ b/spatio_flux/visualizations/particle_traces.py
@@ -62,16 +62,15 @@ class ParticleTraces(Visualization):
     def inputs(self):
         return {"particles": "map[particle]"}
 
-    def update(self, state):
+    def accumulate(self, state):
         if not hasattr(self, "_history") or self._history is None:
             self._history = []
         particles = state.get("particles") or {}
         # Copy so mutations to live state don't corrupt history frames.
         frame = {pid: dict(p) for pid, p in particles.items() if isinstance(p, dict)}
         self._history.append(frame)
-        return {"html": self._render()}
 
-    def _render(self) -> str:
+    def render(self) -> str:
         cfg = getattr(self, "config", None) or {}
         title = cfg.get("title", "particle traces")
         bounds = cfg.get("bounds") or (50.0, 50.0)

--- a/spatio_flux/visualizations/test_suite_timeseries.py
+++ b/spatio_flux/visualizations/test_suite_timeseries.py
@@ -96,15 +96,14 @@ class TestSuiteTimeSeries(Visualization):
         fields = (getattr(self, "config", None) or {}).get("field_names") or []
         return {name: "float" for name in fields}
 
-    def update(self, state):
+    def accumulate(self, state):
         if not hasattr(self, "_history") or self._history is None:
             self._history = []
         fields = (getattr(self, "config", None) or {}).get("field_names") or []
         snapshot = {name: _coerce_float(state.get(name)) for name in fields}
         self._history.append(snapshot)
-        return {"html": self._render()}
 
-    def _render(self) -> str:
+    def render(self) -> str:
         cfg = getattr(self, "config", None) or {}
         fields = cfg.get("field_names") or []
         title = cfg.get("title", "timeseries")

--- a/tests/test_demo_visualizations.py
+++ b/tests/test_demo_visualizations.py
@@ -1,4 +1,9 @@
-"""Tests for the FieldHeatmap viz that ships with spatio-flux."""
+"""Tests for the FieldHeatmap viz that ships with spatio-flux.
+
+These vizes now use the new ``accumulate(state)`` + ``render()`` contract
+from ``pbg_superpowers.visualization.Visualization`` (v0.9.0+), so tests
+exercise the two-phase path: accumulate per tick, then render once.
+"""
 import numpy as np
 
 from spatio_flux.visualizations.field_animation_gif import FieldAnimationGif
@@ -6,41 +11,64 @@ from spatio_flux.visualizations.field_heatmap import FieldHeatmap
 from pbg_superpowers.visualization import Visualization
 
 
-def test_field_heatmap_renders_from_list():
+# --- FieldHeatmap ----------------------------------------------------------
+
+def _heatmap(**config):
     inst = FieldHeatmap.__new__(FieldHeatmap)
-    inst.config = {'title': 'glucose', 'colorscale': 'Viridis'}
-    out = inst.update({'field': [[1.0, 0.5], [0.3, 0.1]]})
-    assert 'html' in out
-    assert 'Plotly' in out['html']
-    assert 'heatmap' in out['html']
-    assert 'glucose' in out['html']
+    inst.config = config
+    return inst
+
+
+def test_field_heatmap_renders_from_list():
+    inst = _heatmap(title='glucose', colorscale='Viridis')
+    inst.accumulate({'field': [[1.0, 0.5], [0.3, 0.1]]})
+    html = inst.render()
+    assert 'Plotly' in html
+    assert 'heatmap' in html
+    assert 'glucose' in html
 
 
 def test_field_heatmap_renders_from_numpy():
-    inst = FieldHeatmap.__new__(FieldHeatmap)
-    inst.config = {'title': '', 'colorscale': 'Viridis'}
+    inst = _heatmap(title='', colorscale='Viridis')
     field = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float64)
-    out = inst.update({'field': field})
-    assert 'html' in out
-    assert 'Plotly' in out['html']
-    # Values should appear in the JSON-encoded traces.
-    assert '6.0' in out['html']
+    inst.accumulate({'field': field})
+    html = inst.render()
+    assert 'Plotly' in html
+    assert '6.0' in html
 
 
 def test_field_heatmap_handles_missing_field():
-    inst = FieldHeatmap.__new__(FieldHeatmap)
-    inst.config = {'title': '', 'colorscale': 'Viridis'}
-    out = inst.update({})
+    inst = _heatmap(title='', colorscale='Viridis')
+    inst.accumulate({})
+    html = inst.render()
     # Renders a degenerate (empty) heatmap rather than raising.
-    assert 'html' in out
-    assert 'Plotly' in out['html']
+    assert 'Plotly' in html
 
 
 def test_field_heatmap_handles_flat_list():
-    inst = FieldHeatmap.__new__(FieldHeatmap)
-    inst.config = {'title': '', 'colorscale': 'Viridis'}
-    out = inst.update({'field': [1.0, 2.0, 3.0]})
+    inst = _heatmap(title='', colorscale='Viridis')
+    inst.accumulate({'field': [1.0, 2.0, 3.0]})
+    html = inst.render()
     # _to_2d_list wraps a flat list as a single row.
+    assert 'Plotly' in html
+
+
+def test_field_heatmap_default_end_mode_emits_empty_html_per_tick():
+    """In default ``render_mode='end'``, the per-tick update() must NOT
+    materialize HTML — that's what avoided the O(T²) regression."""
+    inst = _heatmap(title='glucose', colorscale='Viridis')
+    out = inst.update({'field': [[1.0, 0.5], [0.3, 0.1]]})
+    assert out == {'html': ''}
+    # But state was accumulated, so render() works on demand.
+    assert 'Plotly' in inst.render()
+
+
+def test_field_heatmap_stream_mode_renders_each_tick():
+    """``render_mode='stream'`` opts back into the legacy per-tick HTML
+    contract for callers that need it."""
+    inst = _heatmap(title='glucose', colorscale='Viridis',
+                    render_mode='stream')
+    out = inst.update({'field': [[1.0, 0.5]]})
     assert 'Plotly' in out['html']
 
 
@@ -58,45 +86,52 @@ def test_field_heatmap_demo_dict():
     assert isinstance(demo['field'], list)
 
 
-def test_field_animation_gif_renders_a_gif():
+# --- FieldAnimationGif -----------------------------------------------------
+
+def _gif(**config):
     inst = FieldAnimationGif.__new__(FieldAnimationGif)
-    inst.config = {
-        'field_names': ['glucose', 'acetate'],
-        'title': 'demo animation',
-        'fps': 4,
-        'cmap': 'viridis',
-    }
+    inst.config = config
     inst._history = []
-    # Push three timesteps with two fields each.
+    return inst
+
+
+def test_field_animation_gif_renders_a_gif():
+    inst = _gif(
+        field_names=['glucose', 'acetate'],
+        title='demo animation', fps=4, cmap='viridis',
+    )
     for k in range(3):
-        out = inst.update({
+        inst.accumulate({
             'glucose': np.array([[1.0 + k, 0.5], [0.3, 0.1]], dtype=float),
             'acetate': np.array([[0.0, 0.1 + k], [0.2, 0.3]], dtype=float),
         })
-    assert 'html' in out
-    html = out['html']
+    html = inst.render()
     assert 'data:image/gif;base64,' in html
-    # Strip the prefix and decode to confirm we produced non-zero GIF bytes.
     b64 = html.split('data:image/gif;base64,', 1)[1].split('"', 1)[0]
     import base64 as _b64
     gif_bytes = _b64.b64decode(b64)
     assert len(gif_bytes) > 0
-    # GIF magic header.
     assert gif_bytes[:6] in (b'GIF87a', b'GIF89a')
 
 
 def test_field_animation_gif_handles_no_data():
-    inst = FieldAnimationGif.__new__(FieldAnimationGif)
-    inst.config = {
-        'field_names': ['glucose'],
-        'title': '',
-        'fps': 4,
-        'cmap': 'viridis',
-    }
-    inst._history = []
-    # Update with no data -> render falls back to placeholder.
-    out = inst.update({})
-    assert 'html' in out
-    assert 'No field data yet' in out['html']
-    # No GIF data URI should be emitted.
-    assert 'data:image/gif' not in out['html']
+    inst = _gif(field_names=['glucose'], title='', fps=4, cmap='viridis')
+    inst.accumulate({})
+    html = inst.render()
+    assert 'No field data yet' in html
+    assert 'data:image/gif' not in html
+
+
+def test_field_animation_gif_end_mode_skips_per_tick_render():
+    """The whole point of this PR: per-tick update() must NOT trigger the
+    full GIF re-encode that caused the O(T²) regression."""
+    inst = _gif(field_names=['glucose'], title='', fps=4, cmap='viridis')
+    for k in range(5):
+        out = inst.update({
+            'glucose': np.array([[1.0 + k, 0.5]], dtype=float),
+        })
+        assert out == {'html': ''}, f'tick {k} unexpectedly emitted html'
+    # All 5 frames are still accumulated for the final render.
+    assert len(inst._history) == 5
+    html = inst.render()
+    assert 'data:image/gif;base64,' in html

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "pbg-superpowers"
-version = "0.7.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bigraph-schema" },
@@ -1109,9 +1109,9 @@ dependencies = [
     { name = "process-bigraph" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/5e/5c5f6830b752bd46a95d1968e0ea86f937e4703038afd671ec3ef1ffc8df/pbg_superpowers-0.7.0.tar.gz", hash = "sha256:67ad07d55679a5525ef5fc050049c73da0f4eb92e294f9a09b1869fdee8fd427", size = 123375, upload-time = "2026-05-12T15:35:06.216Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/5b/2d535ca7c7c6ac9ed57c894b18956df72aa0409a973584a67700c2dafe55/pbg_superpowers-0.9.0.tar.gz", hash = "sha256:39b959c6f87ebcaf1e34d87056f30eedb385db2aa4940a4895c0eaee8d0b9fe3", size = 195177, upload-time = "2026-05-16T02:38:32.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/e5/7ba1762dcdc11a4384e131a16e09d690a88a2ebcaa367265756daf173d7e/pbg_superpowers-0.7.0-py3-none-any.whl", hash = "sha256:c2d262ee238d30ff936bd41735d25785eb20e24ff3e603ec7793c9d2b389e2c6", size = 48855, upload-time = "2026-05-12T15:35:04.798Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ea/67fa39772670aa5e0201c97797e0f3a1e2e210f9d565055f06ec37291172/pbg_superpowers-0.9.0-py3-none-any.whl", hash = "sha256:2cff9135fa5f3f4c9f5f2c39735e56067c8cc90498597d736396c99e11c3f94c", size = 53355, upload-time = "2026-05-16T02:38:30.853Z" },
 ]
 
 [[package]]
@@ -1832,7 +1832,7 @@ requires-dist = [
     { name = "imageio" },
     { name = "ipython" },
     { name = "matplotlib" },
-    { name = "pbg-superpowers", specifier = ">=0.4.16" },
+    { name = "pbg-superpowers", specifier = ">=0.9.0" },
     { name = "process-bigraph", extras = ["ray", "server-rest", "ec2-ssm"] },
     { name = "pymunk" },
     { name = "scipy" },


### PR DESCRIPTION
## Summary

Migrates the five inline Visualization Steps in `spatio_flux/visualizations/` to the new `accumulate(state)` + `render()` contract from [pbg-superpowers 0.9.0](https://github.com/vivarium-collective/pbg-superpowers/pull/9), and bumps the dep pin.

- **`FieldHeatmap`, `FieldAnimationGif`, `FieldSnapshotsGrid`, `TestSuiteTimeSeries`, `ParticleTraces`** now split their old `update()` into:
  - `accumulate(state)` — buffer one tick into `self._history` (or `_last_field`)
  - `render()` — produce the final HTML from the buffer
- With the new baseclass default `render_mode='end'`, the runtime's per-tick path is just an `accumulate()` call; HTML is built once via `render_results()` at end-of-run (or per-tick if a caller opts into `render_mode='stream'`).

## Why

The 2026-05-13 viz commits (`1f875f1`, `2daff23`, `8d52982`) bundled these Steps into the composite generators that `test_suite.py` runs. Each Step's old `update()` rebuilt its full output on every tick — `FieldAnimationGif` re-encoded the entire animated GIF every step, turning O(T) test runs into O(T²). The gh-pages report's total simulation time jumped from **127s → 2489s** as a result.

Micro-bench on `FieldAnimationGif` (50 ticks, 8×8 fields):

| Mode | Per-tick path (50 ticks) | Final render |
|---|---:|---:|
| `end` (new default) | **0.0003s** | 2.25s (one-shot) |
| `stream` (legacy opt-in) | **58.3s** | 2.30s |

For CI test_suite runs — which never call `render_results` — viz cost effectively collapses to zero.

## Test plan

- [x] `tests/test_demo_visualizations.py` updated for new contract (12 passing tests, was 9), including two new tests that explicitly assert the per-tick `update()` returns empty html in default mode
- [x] Bench above run locally vs. the editable pbg-superpowers checkout
- [ ] Run-Simulation-Tests workflow on this branch confirms the gh-pages report's "Total Simulation Time" drops back to ~127s (down from 2489s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)