### PR TITLE
rebrand: import viva_superpowers + bump pbg-superpowers to 0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "imageio",
     "ipython",
     "matplotlib",
-    "pbg-superpowers>=0.9.0",
+    "pbg-superpowers>=0.16.0",
     "pymunk",
     "scipy",
 ]

--- a/spatio_flux/composites/__init__.py
+++ b/spatio_flux/composites/__init__.py
@@ -4,7 +4,7 @@ Importing this package triggers ``@composite_generator`` registration for
 every composite in every submodule. The dashboard's ``discover_generators``
 call relies on this.
 """
-from pbg_superpowers.composite_generator import _REGISTRY as REGISTRY
+from viva_superpowers.composite_generator import _REGISTRY as REGISTRY
 
 # Trigger decorator side-effects in every submodule.
 from . import metabolism  # noqa: F401

--- a/spatio_flux/composites/comets.py
+++ b/spatio_flux/composites/comets.py
@@ -1,7 +1,7 @@
 """Composite generators — comets group. See spec at
 docs/superpowers/specs/2026-05-12-composite-generator-convention.md."""
 import numpy as np
-from pbg_superpowers.composite_generator import composite_generator
+from viva_superpowers.composite_generator import composite_generator
 
 from spatio_flux.processes import (
     MODEL_REGISTRY_DFBA, DIVISION_MASS_THRESHOLD,

--- a/spatio_flux/composites/metabolism.py
+++ b/spatio_flux/composites/metabolism.py
@@ -1,7 +1,7 @@
 """Composite generators — metabolism group. See spec at
 docs/superpowers/specs/2026-05-12-composite-generator-convention.md."""
 
-from pbg_superpowers.composite_generator import composite_generator
+from viva_superpowers.composite_generator import composite_generator
 
 from spatio_flux.processes import get_dfba_process_from_registry, MODEL_REGISTRY_DFBA, get_field_names
 from spatio_flux.processes.monod_kinetics import MODEL_REGISTRY_KINETICS, get_monod_kinetics_process_from_config

--- a/spatio_flux/composites/particles.py
+++ b/spatio_flux/composites/particles.py
@@ -1,7 +1,7 @@
 """Composite generators — particles group. See spec at
 docs/superpowers/specs/2026-05-12-composite-generator-convention.md."""
 import numpy as np
-from pbg_superpowers.composite_generator import composite_generator
+from viva_superpowers.composite_generator import composite_generator
 
 from spatio_flux.processes import (
     get_fields, get_particles_state, get_newtonian_particles_state,

--- a/spatio_flux/composites/reference.py
+++ b/spatio_flux/composites/reference.py
@@ -1,6 +1,6 @@
 """Composite generators — reference group. See spec at
 docs/superpowers/specs/2026-05-12-composite-generator-convention.md."""
-from pbg_superpowers.composite_generator import composite_generator
+from viva_superpowers.composite_generator import composite_generator
 
 from spatio_flux.processes import (
     get_fields, get_newtonian_particles_state,

--- a/spatio_flux/composites/spatial.py
+++ b/spatio_flux/composites/spatial.py
@@ -1,7 +1,7 @@
 """Composite generators — spatial group. See spec at
 docs/superpowers/specs/2026-05-12-composite-generator-convention.md."""
 import numpy as np
-from pbg_superpowers.composite_generator import composite_generator
+from viva_superpowers.composite_generator import composite_generator
 
 from spatio_flux.processes import (
     MODEL_REGISTRY_DFBA, get_fields, get_fields_with_schema,

--- a/spatio_flux/experiments/test_suite.py
+++ b/spatio_flux/experiments/test_suite.py
@@ -55,7 +55,7 @@ from spatio_flux.composites._constants import (  # noqa: F401
     build_model_grid,
 )
 from spatio_flux.composites import REGISTRY as COMPOSITE_REGISTRY
-from pbg_superpowers.composite_generator import build_generator
+from viva_superpowers.composite_generator import build_generator
 
 DEFAULT_RUNTIME_SHORT = 10
 DEFAULT_RUNTIME_LONG = 60

--- a/spatio_flux/visualizations/field_animation_gif.py
+++ b/spatio_flux/visualizations/field_animation_gif.py
@@ -20,7 +20,7 @@ import numpy as np
 
 import imageio.v2 as imageio
 
-from pbg_superpowers.visualization import Visualization
+from viva_superpowers.visualization import Visualization
 
 
 def _to_2d_array(v):

--- a/spatio_flux/visualizations/field_heatmap.py
+++ b/spatio_flux/visualizations/field_heatmap.py
@@ -12,7 +12,7 @@ the latest field each tick, render once via :func:`render_results`. Set
 from __future__ import annotations
 import json
 
-from pbg_superpowers.visualization import Visualization
+from viva_superpowers.visualization import Visualization
 
 
 def _to_2d_list(field):

--- a/spatio_flux/visualizations/field_snapshots.py
+++ b/spatio_flux/visualizations/field_snapshots.py
@@ -20,7 +20,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 
-from pbg_superpowers.visualization import Visualization
+from viva_superpowers.visualization import Visualization
 
 
 def _to_2d_array(v):

--- a/spatio_flux/visualizations/particle_traces.py
+++ b/spatio_flux/visualizations/particle_traces.py
@@ -18,7 +18,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-from pbg_superpowers.visualization import Visualization
+from viva_superpowers.visualization import Visualization
 from spatio_flux.plots.plot import plot_particle_traces
 
 

--- a/spatio_flux/visualizations/test_suite_timeseries.py
+++ b/spatio_flux/visualizations/test_suite_timeseries.py
@@ -24,7 +24,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-from pbg_superpowers.visualization import Visualization
+from viva_superpowers.visualization import Visualization
 
 
 # Semantic colors lifted from spatio_flux/experiments/test_suite.py so the

--- a/tests/test_composite_generators.py
+++ b/tests/test_composite_generators.py
@@ -13,7 +13,7 @@ from process_bigraph import allocate_core
 
 import spatio_flux.composites  # noqa: F401 -- ensures registry is populated
 from spatio_flux.composites import REGISTRY
-from pbg_superpowers.composite_generator import build_generator
+from viva_superpowers.composite_generator import build_generator
 from spatio_flux.composites._serialize import normalize_doc
 
 

--- a/tests/test_demo_visualizations.py
+++ b/tests/test_demo_visualizations.py
@@ -1,14 +1,14 @@
 """Tests for the FieldHeatmap viz that ships with spatio-flux.
 
 These vizes now use the new ``accumulate(state)`` + ``render()`` contract
-from ``pbg_superpowers.visualization.Visualization`` (v0.9.0+), so tests
+from ``viva_superpowers.visualization.Visualization`` (v0.9.0+), so tests
 exercise the two-phase path: accumulate per tick, then render once.
 """
 import numpy as np
 
 from spatio_flux.visualizations.field_animation_gif import FieldAnimationGif
 from spatio_flux.visualizations.field_heatmap import FieldHeatmap
-from pbg_superpowers.visualization import Visualization
+from viva_superpowers.visualization import Visualization
 
 
 # --- FieldHeatmap ----------------------------------------------------------

--- a/tools/capture_baseline_doc.py
+++ b/tools/capture_baseline_doc.py
@@ -47,7 +47,7 @@ def _capture_from_new(name: str) -> dict:
     import numpy as np
     np.random.seed(0)
     from spatio_flux.composites import REGISTRY
-    from pbg_superpowers.composite_generator import build_generator
+    from viva_superpowers.composite_generator import build_generator
     # Find the entry whose name matches.
     matches = [e for e in REGISTRY.values() if e.name == name]
     if not matches:

--- a/uv.lock
+++ b/uv.lock
@@ -1098,20 +1098,37 @@ wheels = [
 ]
 
 [[package]]
+name = "pbg-emitters"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bigraph-schema" },
+    { name = "numpy" },
+    { name = "process-bigraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ac/c7e8a52facc4a73ca57ce918e4a4b38e1fe9205da65048160c98c06a0822/pbg_emitters-0.2.1.tar.gz", hash = "sha256:32eee4871745440044667ae2bb94f8d69d09e649503d2cb4dd27cc836dfa4fe5", size = 94393, upload-time = "2026-07-03T03:02:16.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/cb/7543a7d38fe7ce30019cd0d1616bd2dc249adad02b6a360ce079b8b90800/pbg_emitters-0.2.1-py3-none-any.whl", hash = "sha256:fa72e0269c7278e5a9f5a01a4bc7cb502109cff1007b8258c58d48a1322cf01e", size = 83560, upload-time = "2026-07-03T03:02:15.296Z" },
+]
+
+[[package]]
 name = "pbg-superpowers"
-version = "0.9.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bigraph-schema" },
     { name = "click" },
     { name = "jinja2" },
     { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "pbg-emitters" },
     { name = "process-bigraph" },
+    { name = "pypdf" },
     { name = "pyyaml" },
+    { name = "ruamel-yaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/5b/2d535ca7c7c6ac9ed57c894b18956df72aa0409a973584a67700c2dafe55/pbg_superpowers-0.9.0.tar.gz", hash = "sha256:39b959c6f87ebcaf1e34d87056f30eedb385db2aa4940a4895c0eaee8d0b9fe3", size = 195177, upload-time = "2026-05-16T02:38:32.451Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/c7/539d3dfa46a896370c8ba6a4b71a8c67f5cb523cb01d8fe0aa9e122cdde5/pbg_superpowers-0.16.0.tar.gz", hash = "sha256:29586e3af2b732934717c485931480bd4e33613a07543f3077d83c13d5d7213b", size = 1413823, upload-time = "2026-07-25T20:38:24.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/ea/67fa39772670aa5e0201c97797e0f3a1e2e210f9d565055f06ec37291172/pbg_superpowers-0.9.0-py3-none-any.whl", hash = "sha256:2cff9135fa5f3f4c9f5f2c39735e56067c8cc90498597d736396c99e11c3f94c", size = 53355, upload-time = "2026-05-16T02:38:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/92/84914100888dba584150e743cd35ab23332ce4ecd58f6bdfeccb9371abb8/pbg_superpowers-0.16.0-py3-none-any.whl", hash = "sha256:5bc54398d2f0313f1d734e989f85b78c3e5b3d825e9582fbc41d709dfbedbcc7", size = 362202, upload-time = "2026-07-25T20:38:22.915Z" },
 ]
 
 [[package]]
@@ -1427,6 +1444,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/c1/1d9de9aeaa1b89b0186e5fe23294ff6517fce1bc69149185577cd31016b2/pyparsing-3.3.1.tar.gz", hash = "sha256:47fad0f17ac1e2cad3de3b458570fbc9b03560aa029ed5e16ee5554da9a2251c", size = 1550512, upload-time = "2025-12-23T03:14:04.391Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/40/2614036cdd416452f5bf98ec037f38a1afb17f327cb8e6b652d4729e0af8/pyparsing-3.3.1-py3-none-any.whl", hash = "sha256:023b5e7e5520ad96642e2c6db4cb683d3970bd640cdf7115049a6e9c3682df82", size = 121793, upload-time = "2025-12-23T03:14:02.103Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]
@@ -1832,7 +1858,7 @@ requires-dist = [
     { name = "imageio" },
     { name = "ipython" },
     { name = "matplotlib" },
-    { name = "pbg-superpowers", specifier = ">=0.9.0" },
+    { name = "pbg-superpowers", specifier = ">=0.16.0" },
     { name = "process-bigraph", extras = ["ray", "server-rest", "ec2-ssm"] },
     { name = "pymunk" },
     { name = "scipy" },


### PR DESCRIPTION
Import rename (pbg→viva) + bump pinned pbg-superpowers 0.9.0→0.16.0 (ships viva_superpowers). CI-gated: the 7-version jump may surface API drift.