### PR TITLE
fix(ci): reproduce.py resolves scripts package on sys.path

### DIFF
--- a/.github/workflows/publish-report-and-workbench.yml
+++ b/.github/workflows/publish-report-and-workbench.yml
@@ -69,7 +69,10 @@ jobs:
       - name: Reproduce the investigation (run all studies + build report)
         # Runs every study's post-run analysis flush (charts + zarr run-stores)
         # and builds report/index.html. Run inside the venv (not `uv run`, which
-        # would re-sync and undo the workbench@main install).
+        # would re-sync and undo the workbench@main install). PYTHONPATH puts the
+        # repo root on the path so `scripts.*` imports resolve.
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           source .venv/bin/activate
           python scripts/reproduce.py --out report/index.html

--- a/scripts/reproduce.py
+++ b/scripts/reproduce.py
@@ -17,6 +17,12 @@ import sys
 import yaml
 
 REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Ensure the repo root is importable so `from scripts.build_report import ...`
+# works when invoked as `python scripts/reproduce.py` (which puts scripts/ on
+# sys.path, not the repo root).
+if REPO not in sys.path:
+    sys.path.insert(0, REPO)
 INVESTIGATION = os.path.join("investigations", "spatio-flux-test-suite", "investigation.yaml")
 
 


### PR DESCRIPTION
The post-merge publish workflow failed with `ModuleNotFoundError: No module named 'scripts'`. `python scripts/reproduce.py` puts `scripts/` on `sys.path` (not the repo root), so `from scripts.build_report import ...` failed *after* all 19 studies ran successfully. Fix: insert the repo root into `sys.path` in `reproduce.py` + set `PYTHONPATH` on the workflow's reproduce step.

Note: the 19 studies ran fine in ~11 min in CI — the concentration→delta-type perf fix held (no hang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)