### PR TITLE
publish: add .nojekyll to gh-pages (fixes Resources tab 404 on _global.json)

### DIFF
--- a/.github/workflows/publish-report-and-workbench.yml
+++ b/.github/workflows/publish-report-and-workbench.yml
@@ -108,8 +108,11 @@ jobs:
           cp -R report/. /tmp/ghp/report/
           cp -R workbench-site/. /tmp/ghp/workbench/
           cp -R figures-site/. /tmp/ghp/figures/
+          # Disable Jekyll so underscore-prefixed api files (e.g. api/inputs/_global.json)
+          # are served instead of silently dropped — otherwise the Resources tab 404s.
+          touch /tmp/ghp/.nojekyll
           cd /tmp/ghp
-          git add report workbench figures
+          git add report workbench figures .nojekyll
           if git diff --cached --quiet; then
             echo "no changes to publish"
           else


### PR DESCRIPTION
The read-only workbench's **Resources** tab errored with `fetch …/api/inputs/_global.json -> 404`. GitHub Pages runs Jekyll by default, and Jekyll **drops files whose name starts with `_`** — so `api/inputs/_global.json` was never served even though it's on `gh-pages`.

Fix: `touch /tmp/ghp/.nojekyll` (and `git add` it) in the publish deploy step, so every republish disables Jekyll and serves all files. (Already hot-fixed on the live `gh-pages` branch; this makes it durable.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)