### PR TITLE
composites: science-facing descriptions across the registry

### DIFF
--- a/scripts/export_draft_composites.py
+++ b/scripts/export_draft_composites.py
@@ -22,18 +22,25 @@ OUT = Path(__file__).resolve().parents[1] / "spatio_flux" / "composites"
 
 SPECS = [
     ("fig01a-draft-processes", "Fig 1a", pf.fig1a_processes_state, False,
-     "Four draft-process cards — Gene Expression (ODE), Metabolism (FBA), Morphogen "
-     "Gradient (PDE), Multicellular Interactions (ABM). Unwired: ports + contracts "
-     "only, no stores."),
+     "Five draft-process cards, one per modeling formalism — Gene Expression (ODE), "
+     "Metabolism (Flux Balance Analysis), Morphogen Gradient (reaction–diffusion PDE), "
+     "Multicellular Interactions (Agent-Based Model), and Neural Dynamics (ML "
+     "surrogate). Each is unwired: typed ports + a governing-equation contract, no "
+     "stores and no update dynamics."),
     ("fig01b-multiscale-composite", "Fig 1b", pf.fig1b_multiscale_state, True,
-     "The multiscale draft composite: tissue ⊃ {fields, cell_population, cells ⊃ "
-     "cell ⊃ molecules}. Molecular ODEs, FBA metabolism, structural packing, "
-     "growth/division, and tissue-scale diffusion + ABM — all draft processes."),
+     "A multiscale draft composite spanning molecules → tissue: tissue ⊃ {fields, "
+     "cell_population ⊃ cell (×10, collapsed) ⊃ molecules}. Each cell runs molecular "
+     "ODEs (transcription / translation / degradation), FBA metabolism, structural "
+     "packing, and growth / division; tissue-scale diffusion and multicellular "
+     "interactions (ABM) couple the population. All processes are draft — typed ports "
+     "+ contracts, no dynamics."),
     ("fig01c-study-workflow", "Fig 1c", pf.fig1c_study_workflow_state, False,
-     "A study workflow: a draft Preprocess step feeds three parallel community-dFBA "
-     "simulations (real, zoomable composites — the same real study template ×3); "
-     "their outputs feed a draft Analysis + Visualization step. Pre/post are draft; "
-     "the parallel simulations are a real composite."),
+     "A study-workflow composite: a draft Preprocess step configures three parallel "
+     "community-dFBA simulations (each a drillable sub-composite wrapping the real "
+     "community-dFBA model); an Emitter captures their state into an emitter-data "
+     "store, a LoadResults step reads it into a results table, and draft Analyses / "
+     "Visualizations / Tests steps consume the results. The pre/post steps are draft; "
+     "the simulations are real composites."),
     # Fig 2: the SAME place graph (nodes n1..n6) read two ways — as a Milner link
     # graph (2a, hyperedges e1/e2/e3) and as a process graph (2b, processes
     # p1/p2/p3). Two composites so each panel carries its own labels.

--- a/spatio_flux/composites/comets.py
+++ b/spatio_flux/composites/comets.py
@@ -23,9 +23,9 @@ from spatio_flux.composites._constants import (
 @composite_generator(
     name="comets_diffusion",
     description=(
-        "Two-phase coupling (no particles): spatial dFBA on a lattice with "
-        "advection–diffusion of substrates + biomass. The classic COMETS "
-        "field-only scenario."
+        "The classic COMETS field-only scenario: per-site dFBA on a lattice "
+        "coupled to advection–diffusion of glucose, acetate, and dissolved "
+        "biomass, with biomass seeded at the top edge."
     ),
     parameters={
         "dissolved_model_id": {"type": "string", "default": "ecoli core"},
@@ -73,10 +73,10 @@ def comets_diffusion(core=None, *, dissolved_model_id="ecoli core",
 @composite_generator(
     name="comets_spatial_dfba",
     description=(
-        "COMETS with a SINGLE vectorized SpatialDFBA process: one process "
-        "updates every lattice site as a batched structured state — instead of "
-        "one dFBA process per bin — so the field-only COMETS scenario scales to "
-        "much larger grids. Coupled to advection-diffusion of substrates + biomass."
+        "The field-only COMETS scenario driven by a single vectorized dFBA "
+        "process that updates every lattice site at once, coupled to advection–"
+        "diffusion of glucose, acetate, and dissolved biomass — scaling the "
+        "per-site approach to large grids."
     ),
     parameters={
         "model_id":       {"type": "string", "default": "ecoli core"},
@@ -128,9 +128,10 @@ def comets_spatial_dfba(core=None, *, model_id="ecoli core",
 @composite_generator(
     name="comets_br_particles_kinetics",
     description=(
-        "Three-way coupling: spatial dFBA fields + Brownian particle "
-        "agents that run Monod kinetics locally + diffusion. End-to-end "
-        "smoke test of the COMETS-style composite stack with kinetic agents."
+        "A COMETS-style scenario coupling lattice dFBA fields, advection–"
+        "diffusion, and Brownian agents that run Monod kinetics against local "
+        "concentrations, exchanging substrate with the fields and dividing at "
+        "a mass threshold."
     ),
     parameters={
         "division_mass_threshold": {"type": "float",  "default": DIVISION_MASS_THRESHOLD},
@@ -196,9 +197,10 @@ def comets_br_particles_kinetics(
 @composite_generator(
     name="comets_br_particles_dfba",
     description=(
-        "Full COMETS-style spatial composite: lattice dFBA + advection–"
-        "diffusion + Brownian particles with internal dFBA + division. "
-        "End-to-end coupled scenario."
+        "The full COMETS-style composite: per-site lattice dFBA and advection–"
+        "diffusion of substrates coupled to Brownian particles that each run "
+        "an internal dFBA model, exchange with the fields, and divide as "
+        "biomass accumulates."
     ),
     parameters={
         "particle_model_id":       {"type": "string", "default": "ecoli core"},
@@ -266,9 +268,10 @@ def comets_br_particles_dfba(
 @composite_generator(
     name="comets_nt_particles_dfba",
     description=(
-        "Mechanochemical + metabolic coupling: Pymunk particles move/"
-        "collide while COMETS fields diffuse; particles run metabolism "
-        "(via exchange) against local concentrations."
+        "Pymunk rigid-body particles that collide and settle under gravity "
+        "while COMETS fields diffuse and a lattice kinetics process consumes "
+        "substrate; each particle runs an internal dFBA model, exchanging with "
+        "the local fields and dividing as it grows."
     ),
     parameters={
         "particle_model_id":  {"type": "string", "default": "ecoli core"},

--- a/spatio_flux/composites/fig01a-draft-processes.composite.json
+++ b/spatio_flux/composites/fig01a-draft-processes.composite.json
@@ -1,6 +1,6 @@
 {
   "name": "fig01a-draft-processes",
-  "description": "Fig 1a \u2014 Four draft-process cards \u2014 Gene Expression (ODE), Metabolism (FBA), Morphogen Gradient (PDE), Multicellular Interactions (ABM). Unwired: ports + contracts only, no stores.",
+  "description": "Fig 1a \u2014 Five draft-process cards, one per modeling formalism \u2014 Gene Expression (ODE), Metabolism (Flux Balance Analysis), Morphogen Gradient (reaction\u2013diffusion PDE), Multicellular Interactions (Agent-Based Model), and Neural Dynamics (ML surrogate). Each is unwired: typed ports + a governing-equation contract, no stores and no update dynamics.",
   "tags": [
     "paper-figure",
     "draft",

--- a/spatio_flux/composites/fig01b-multiscale-composite.composite.json
+++ b/spatio_flux/composites/fig01b-multiscale-composite.composite.json
@@ -1,6 +1,6 @@
 {
   "name": "fig01b-multiscale-composite",
-  "description": "Fig 1b \u2014 The multiscale draft composite: tissue \u2283 {fields, cell_population, cells \u2283 cell \u2283 molecules}. Molecular ODEs, FBA metabolism, structural packing, growth/division, and tissue-scale diffusion + ABM \u2014 all draft processes.",
+  "description": "Fig 1b \u2014 A multiscale draft composite spanning molecules \u2192 tissue: tissue \u2283 {fields, cell_population \u2283 cell (\u00d710, collapsed) \u2283 molecules}. Each cell runs molecular ODEs (transcription / translation / degradation), FBA metabolism, structural packing, and growth / division; tissue-scale diffusion and multicellular interactions (ABM) couple the population. All processes are draft \u2014 typed ports + contracts, no dynamics.",
   "tags": [
     "paper-figure",
     "draft",

--- a/spatio_flux/composites/fig01c-study-workflow.composite.json
+++ b/spatio_flux/composites/fig01c-study-workflow.composite.json
@@ -1,6 +1,6 @@
 {
   "name": "fig01c-study-workflow",
-  "description": "Fig 1c \u2014 A study workflow: a draft Preprocess step feeds three parallel community-dFBA simulations (real, zoomable composites \u2014 the same real study template \u00d73); their outputs feed a draft Analysis + Visualization step. Pre/post are draft; the parallel simulations are a real composite.",
+  "description": "Fig 1c \u2014 A study-workflow composite: a draft Preprocess step configures three parallel community-dFBA simulations (each a drillable sub-composite wrapping the real community-dFBA model); an Emitter captures their state into an emitter-data store, a LoadResults step reads it into a results table, and draft Analyses / Visualizations / Tests steps consume the results. The pre/post steps are draft; the simulations are real composites.",
   "tags": [
     "paper-figure",
     "draft",

--- a/spatio_flux/composites/figures.py
+++ b/spatio_flux/composites/figures.py
@@ -17,10 +17,11 @@ from pbg_superpowers.composite_generator import composite_generator
 @composite_generator(
     name="fig01c-study-workflow",
     description=(
-        "Fig 1c — study workflow: a draft Preprocess step feeds three parallel "
-        "community-dFBA simulations, each a drillable sub-composite (a "
-        "local:Composite process wrapping the real community-dFBA model), whose "
-        "outputs feed a draft Analysis + Visualization step."
+        "Fig 1c — study workflow: a draft Preprocess step configures three parallel "
+        "community-dFBA simulations, each a drillable sub-composite (a local:Composite "
+        "process wrapping the real community-dFBA model). An Emitter captures the "
+        "simulations into an emitter-data store, a LoadResults step reads it into a "
+        "results table, and draft Analyses / Visualizations / Tests steps consume it."
     ),
 )
 def fig01c_study_workflow(core=None):

--- a/spatio_flux/composites/metabolism.py
+++ b/spatio_flux/composites/metabolism.py
@@ -10,8 +10,9 @@ from spatio_flux.processes.monod_kinetics import MODEL_REGISTRY_KINETICS, get_mo
 @composite_generator(
     name="ecoli_core_dfba",
     description=(
-        "Single-cell metabolism baseline: dynamic FBA for E. coli core with "
-        "external glucose/acetate and biomass over time (no space, no particles)."
+        "Dynamic FBA of a single E. coli core cell in a well-mixed medium, "
+        "tracking extracellular glucose and acetate as biomass grows — the "
+        "simplest single-cell metabolism model, with no space or particles."
     ),
     parameters={
         "model_id":       {"type": "string", "default": "ecoli core"},
@@ -43,9 +44,9 @@ def ecoli_core_dfba(core=None, *, model_id="ecoli core",
 @composite_generator(
     name="monod_kinetics",
     description=(
-        "Field-only baseline: Monod uptake/growth on a well-mixed substrate "
-        "pool (no spatial lattice, no particles). Use to sanity-check "
-        "kinetics + mass balance."
+        "Monod uptake and growth kinetics on a well-mixed pool of glucose and "
+        "acetate — the simplest field-only metabolism model, with no spatial "
+        "lattice or particles."
     ),
     parameters={
         "model_id": {"type": "string", "default": "overflow_metabolism"},
@@ -68,9 +69,9 @@ def monod_kinetics(core=None, *, model_id="overflow_metabolism",
 @composite_generator(
     name="ecoli_dfba",
     description=(
-        "Single-cell metabolism (large model): dynamic FBA using iAF1260 "
-        "with tracked extracellular fields (glucose/formate) and biomass. "
-        "Stress-tests solver + exchange wiring."
+        "Dynamic FBA of a single E. coli cell using the genome-scale iAF1260 "
+        "model, tracking extracellular glucose and formate as biomass grows in "
+        "a well-mixed medium."
     ),
     parameters={
         "model_id": {"type": "string", "default": "ecoli"},
@@ -95,9 +96,9 @@ def ecoli_dfba(core=None, *, model_id="ecoli",
 @composite_generator(
     name="yeast_dfba",
     description=(
-        "Single-cell metabolism (yeast): dynamic FBA using iMM904 with "
-        "extracellular glucose and biomass. Cross-model check of the dFBA "
-        "pipeline."
+        "Dynamic FBA of a single yeast cell using the genome-scale iMM904 "
+        "model, tracking extracellular glucose as biomass grows in a "
+        "well-mixed medium."
     ),
     parameters={
         "model_id": {"type": "string", "default": "yeast"},
@@ -120,9 +121,9 @@ def yeast_dfba(core=None, *, model_id="yeast", glucose=5.0, biomass=0.1):
 @composite_generator(
     name="community_dfba",
     description=(
-        "Multi-agent well-mixed community: several independent dFBA "
-        "instances share the same extracellular pools, creating competition / "
-        "cross-feeding dynamics without space."
+        "A well-mixed microbial community where several dFBA species and a "
+        "Monod-kinetic population share the same extracellular substrate pools, "
+        "producing competition and cross-feeding without spatial structure."
     ),
     parameters={
         "dt":                {"type": "float",  "default": 1.0},
@@ -160,9 +161,9 @@ def community_dfba(core=None, *, dt=1.0, kinetic_model_id="acetate_only",
 @composite_generator(
     name="dfba_kinetics_community",
     description=(
-        "Hybrid community (well-mixed): mixes Monod-kinetic agents with "
-        "dFBA agents in a shared environment. Demonstrates heterogeneous "
-        "process composition under one schema."
+        "A well-mixed community pairing a dFBA population with a Monod-kinetic "
+        "population that share the same extracellular glucose and acetate "
+        "pools, coupling two metabolic modeling styles in one environment."
     ),
     parameters={
         "dfba_model_id":      {"type": "string", "default": "ecoli core"},

--- a/spatio_flux/composites/particles.py
+++ b/spatio_flux/composites/particles.py
@@ -20,9 +20,8 @@ from spatio_flux.composites._constants import (
 @composite_generator(
     name="brownian_particles",
     description=(
-        "Particle-only baseline: Brownian motion of agents with mass in "
-        "continuous space (no fields, no metabolism). Checks integrator + "
-        "particle state schema."
+        "Brownian motion of mass-carrying agents in continuous space — the "
+        "particle-only building block, with no fields or metabolism."
     ),
     parameters={
         "n_bins":         {"type": "object", "default": list(SQUARE_BINS)},
@@ -55,9 +54,10 @@ def brownian_particles(core=None, *, n_bins=list(SQUARE_BINS),
 @composite_generator(
     name="br_particles_kinetics",
     description=(
-        "Particle–field coupling (kinetics): Brownian agents sample local "
-        "lattice concentrations and apply Monod-style exchange, modifying "
-        "both particle mass and fields."
+        "Brownian agents diffuse through a lattice of glucose and acetate, "
+        "taking up substrate by Monod kinetics so that exchange updates both "
+        "particle mass and the local fields, with agents dividing once they "
+        "cross a mass threshold."
     ),
     parameters={
         "model_id":                 {"type": "string", "default": "overflow_metabolism"},
@@ -104,9 +104,10 @@ def br_particles_kinetics(core=None, *, model_id="overflow_metabolism",
 @composite_generator(
     name="br_particles_dfba",
     description=(
-        "Particle-embedded metabolism: Brownian agents carry internal dFBA; "
-        "uptake/secretion couples to fields and biomass accumulates into "
-        "particle mass/size."
+        "Brownian agents each run an internal dFBA model, exchanging glucose "
+        "and acetate with the surrounding fields so that metabolic biomass "
+        "accumulates as particle mass and drives division, over a vertical "
+        "glucose gradient."
     ),
     parameters={
         "particle_model_id":        {"type": "string", "default": "ecoli core"},
@@ -159,9 +160,9 @@ def br_particles_dfba(core=None, *, particle_model_id="ecoli core",
 @composite_generator(
     name="newtonian_particles",
     description=(
-        "Physics-only baseline (Pymunk): rigid-body particles with "
-        "collisions/crowding in continuous space. Use to validate contact "
-        "dynamics + boundary enforcement."
+        "Rigid-body particles under gravity that collide and crowd in "
+        "continuous space via a Pymunk physics engine — the mechanics-only "
+        "building block, with no fields or metabolism."
     ),
     parameters={
         "n_particles": {"type": "int",    "default": 1},

--- a/spatio_flux/composites/reference.py
+++ b/spatio_flux/composites/reference.py
@@ -16,9 +16,10 @@ from spatio_flux.composites._constants import (
 @composite_generator(
     name="spatioflux_reference_demo",
     description=(
-        "SpatioFlux demonstration reference composite: Newtonian motile "
-        "particles + particle–field exchange + internal multi-dFBA + "
-        "Monod/diffusion fields + mass-aggregated division."
+        "The flagship SpatioFlux reference model: Newtonian particles, each "
+        "carrying a two-strain E. coli community with its own internal dFBA, "
+        "swim through diffusing glucose and acetate fields, exchange substrate "
+        "locally, and divide by splitting sub-masses between daughters."
     ),
     parameters={
         "bounds":      {"type": "object", "default": list(SQUARE_BOUNDS)},
@@ -119,7 +120,12 @@ def spatioflux_reference_demo(
 
 @composite_generator(
     name="reference_demo_x2y2",
-    description="Different resolution for the spatio-flux reference demo",
+    description=(
+        "The SpatioFlux reference model on a finer field lattice with doubled "
+        "bin counts in x and y: the same Newtonian particles carrying a "
+        "two-strain internal-dFBA community, with local substrate exchange, "
+        "diffusing glucose/acetate fields, and sub-mass-splitting division."
+    ),
     parameters={
         "bounds":      {"type": "object", "default": list(SQUARE_BOUNDS)},
         "n_bins":      {"type": "object",

--- a/spatio_flux/composites/spatial.py
+++ b/spatio_flux/composites/spatial.py
@@ -18,9 +18,9 @@ from spatio_flux.composites._constants import (
 @composite_generator(
     name="spatial_many_dfba",
     description=(
-        "Spatial microenvironment (sitewise dFBA): a lattice where each site "
-        "runs its own dFBA instance. Useful for validating lattice indexing "
-        "+ per-site state isolation."
+        "A spatial microenvironment where every lattice site runs its own "
+        "dFBA instance over local glucose, acetate, and dissolved biomass, "
+        "resolving metabolism site by site across the grid."
     ),
     parameters={
         "model_id": {"type": "string", "default": "ecoli core"},
@@ -44,9 +44,9 @@ def spatial_many_dfba(core=None, *, model_id="ecoli core",
 @composite_generator(
     name="spatial_dfba_process",
     description=(
-        "Spatial microenvironment (vectorized dFBA): one spatial dFBA "
-        "process updates all lattice sites as a single structured state. "
-        "Demonstrates batched execution + field coupling."
+        "A spatial microenvironment where a single vectorized dFBA process "
+        "updates every lattice site at once, with six microbial species "
+        "arranged in rows across a horizontal glucose gradient."
     ),
     parameters={
         "n_bins": {"type": "object", "default": [5, 6]},
@@ -89,9 +89,10 @@ def spatial_dfba_process(core=None, *, n_bins=[5, 6]):
 @composite_generator(
     name="diffusion_process",
     description=(
-        "Field transport primitive: finite-volume diffusion/advection on a "
-        "2D lattice. Use to validate boundary conditions, stability, and "
-        "transport timescales."
+        "Finite-volume diffusion and advection of solute fields on a 2D "
+        "lattice — glucose diffuses while a seeded band of dissolved biomass "
+        "diffuses and advects — the field-transport building block underlying "
+        "the spatial composites."
     ),
     parameters={
         "n_bins":         {"type": "object", "default": list(DEFAULT_BINS)},


### PR DESCRIPTION
Rewrites every composite `description` to describe **what the model is/does** — its processes, how they couple, the biology/physics — for someone browsing the read-only workbench, instead of internal dev/QA framing ("smoke test", "stress-tests solver", "use to validate lattice indexing", "cross-model check").

Each was verified against its generator body, which surfaced several **accuracy fixes**:
- **Fig 1a** — now **five** cards (adds **Neural Dynamics / ML surrogate**); the old text said "four".
- **Fig 1b / 1c** — updated to the current structure (`cell ×10` under `cell_population`; the `emitter → load_results → results` workflow).
- **community_dfba** — also wires a Monod-kinetic population (was omitted).
- **spatial_dfba_process** — six species across a horizontal glucose gradient.
- **comets_nt_particles_dfba** — field-side kinetics + per-particle internal dFBA.
- **reference_demo_x2y2** — a **finer** lattice (doubled bins), not the vague "different resolution".

Covers the fig* composites (`export_draft_composites.py` + `figures.py`) and the real ones (`metabolism` / `spatial` / `particles` / `comets` / `reference`, ~20). Regenerated the draft-composite JSONs so their exported descriptions match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)