### PR TITLE
publish: force fresh reinstall of vivarium-workbench@main (stale snapshot fix)

### DIFF
--- a/.github/workflows/publish-report-and-workbench.yml
+++ b/.github/workflows/publish-report-and-workbench.yml
@@ -64,7 +64,11 @@ jobs:
         # typed/units API; vivarium-workbench@main for the publish CLI + loom.
         run: |
           uv pip install --upgrade "pbg-superpowers>=0.16" "bigraph-schema>=1.4.3"
-          uv pip install "vivarium-workbench @ git+https://github.com/vivarium-collective/vivarium-workbench.git@main"
+          # --reinstall-package: main's version string can match the already-synced
+          # wheel, so a plain install is skipped and the snapshot ships a STALE loom /
+          # publisher. Force a fresh checkout of main every publish.
+          uv pip install --reinstall-package vivarium-workbench \
+            "vivarium-workbench @ git+https://github.com/vivarium-collective/vivarium-workbench.git@main"
 
       - name: Reproduce the investigation (run all studies + build report)
         # Runs every study's post-run analysis flush (charts + zarr run-stores)


### PR DESCRIPTION
Merged loom/workbench changes weren't reaching the published read-only workbench: gh-pages was missing the composite-header Share button (#811) even after a successful publish.

Cause: the publish step ran `uv pip install "vivarium-workbench @ git+…@main"` with no reinstall flag. Since main's version string matches the wheel already installed by `uv sync --frozen`, uv treats it as satisfied and **skips the install**, so the snapshot ships whatever loom/publisher was already there.

Fix: `--reinstall-package vivarium-workbench` forces a fresh checkout of `@main` on every publish.

Once merged, the next publish will finally deploy the already-merged #809/#810/#811 (default-view fix, both Share buttons, the figure/config overlap fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)